### PR TITLE
Update to geoblacklight schema 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ build
 .cache
 .coverage
 .tox
+*.pyc
 
 docs/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@ sudo: false
 notifications:
   email: false
 language: python
-env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
-  - TOX_ENV=docs
+matrix:
+  include:
+    - env: TOX_ENV=py27
+    - python: 3.5
+      env: TOX_ENV=py35
 install:
   - pip install tox
 script:

--- a/ogre/exceptions.py
+++ b/ogre/exceptions.py
@@ -3,6 +3,5 @@
 
 class InvalidDataError(Exception):
     def __init__(self, field, value):
-        super(InvalidDataError, self).__init__(field, value)
         self.field = field
         self.value = value

--- a/ogre/fields.py
+++ b/ogre/fields.py
@@ -6,165 +6,27 @@ create new kinds of records.
 """
 
 from __future__ import absolute_import
-import decimal
-import arrow
 
 from ogre.exceptions import InvalidDataError
 
 
-class RecordMeta(type):
-    def __new__(cls, clsname, bases, methods):
-        for k, v in methods.items():
-            if isinstance(v, Descriptor):
-                v.name = k
-        return type.__new__(cls, clsname, bases, methods)
+class Enum(object):
+    def __init__(self, *args):
+        self.enums = args
+
+    def __call__(self, f):
+        def wrapped(*args):
+            for arg in args[1:]:
+                if arg not in self.enums:
+                    raise InvalidDataError(f.__name__, arg)
+            f(*args)
+        return wrapped
 
 
-class Descriptor(object):
-    def __init__(self, name=None, **opts):
-        self.name = name
-        for k, v in opts.items():
-            setattr(self, k, v)
-
-    def __set__(self, instance, value):
-        instance.__dict__[self.name] = value
-
-
-class Default(object):
-    """A field type mixin that supports default values.
-
-    Fields using this can define a default value::
-
-        from ogre.record import Record
-        from ogre.fields import Default
-
-        class MyField(Default):
-            pass
-
-        class MyRecord(Record):
-            default_field = MyField(default='Is this dress blue and black?')
-
-        record = MyRecord()
-        record.default_field # 'Is this dress blue and black?'
-    """
-
-    def __get__(self, instance, owner):
+def optional(f):
+    def wrapped(self):
         try:
-            return instance.__dict__.get(self.name, self.default)
+            return f(self)
         except AttributeError:
-            return instance.__dict__.get(self.name)
-
-
-class Enum(Descriptor, Default):
-    """
-    Enumerable field type.
-
-    This defines a field that accepts values from a predetermined list.
-    A mapper function can be passed that is called on the value being
-    set right before it is set. For example::
-
-        from ogre.record import Record
-        from ogre.fields import Enum
-
-        class MyRecord(Record):
-            places = Enum(enums=['MFA', 'MOBA'], mapper=lambda x: x.upper())
-
-        record = MyRecord(places='moba')
-        record.places # MOBA
-
-    :param enums: list of valid values
-    :param mapper: mapper function
-    """
-
-    def __init__(self, name=None, **opts):
-        defaults = {'mapper': lambda x: x}
-        defaults.update(opts)
-        super(Enum, self).__init__(name, **defaults)
-
-    def __set__(self, instance, value):
-        mapped = self.mapper(value)
-        if mapped in self.enums:
-            super(Enum, self).__set__(instance, mapped)
-        else:
-            raise InvalidDataError(self.name, mapped)
-
-
-class String(Descriptor, Default):
-    """
-    A string field type.
-
-    By default, white space will be removed from the beginning and end
-    of the string. Set ``strip_ws`` to ``False`` to disable this behavior.
-
-    :param strip_ws: remove white space from string, default is ``True``
-    """
-
-    def __init__(self, name=None, **opts):
-        defaults = {'strip_ws': True}
-        defaults.update(opts)
-        super(String, self).__init__(name, **defaults)
-
-    def __set__(self, instance, value):
-        if self.strip_ws: value = value.strip()
-        super(String, self).__set__(instance, value)
-
-
-class Decimal(Descriptor, Default):
-    """
-    A decimal field type.
-
-    Calls ``decimal.Decimal()`` on any value being set.
-    """
-
-    def __set__(self, instance, value):
-        super(Decimal, self).__set__(instance, decimal.Decimal(value))
-
-
-class DateTime(Descriptor, Default):
-    """An `arrow <https://github.com/crsmithdev/arrow>`_ datetime field."""
-
-    def __set__(self, instance, value):
-        super(DateTime, self).__set__(instance, arrow.get(value))
-
-
-class Integer(Descriptor, Default):
-    """
-    An integer field type.
-
-    Calls ``int()`` on any value being set.
-    """
-
-    def __set__(self, instance, value):
-        super(Integer, self).__set__(instance, int(value))
-
-
-class Set(Descriptor):
-    """A ``set`` field type.
-
-    Example usage::
-
-        from ogre.record import Record
-
-        record = Record()
-        record.dct_spatial_sm.add("Boston")
-        record.dct_spatial_sm.update(["Cambridge", "Boston"])
-        record.dct_spatial_sm # set(["Boston", "Cambridge"])
-
-    """
-
-    def __set__(self, instance, value):
-        super(Set, self).__set__(instance, set(value))
-
-    def __get__(self, instance, owner):
-        if instance.__dict__.get(self.name) is None:
-            self.__set__(instance, set())
-        return instance.__dict__.get(self.name)
-
-
-class Dictionary(Descriptor):
-    """A ``dict`` field type."""
-
-    def __get__(self, instance, owner):
-        if instance.__dict__.get(self.name) is None:
-            self.__set__(instance, dict())
-        return instance.__dict__.get(self.name)
+            return None
+    return wrapped

--- a/ogre/record.py
+++ b/ogre/record.py
@@ -1,140 +1,160 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import arrow
 import json
-from six import add_metaclass
 
-from ogre.fields import (RecordMeta, String, Enum, Dictionary, DateTime, Set,
-                         Integer, Decimal)
+from ogre.fields import Enum, optional
 
 
-@add_metaclass(RecordMeta)
-class BaseRecord(object):
-    pass
-
-
-class Record(BaseRecord):
-    """Defines a GeoBlacklight record.
-
-    A record's fields (see https://github.com/geoblacklight/geoblacklight-schema)
-    can be initialized through keyword arguments or set later::
-
-        from ogre.record import Record
-
-        record = Record(dc_title_s=u'Cambridge Libraries')
-        record.dct_provenance_s = u'MIT'
-
-    This class can be easily subclassed to create a specific kind of record::
-
-        from ogre.record import Record
-        from ogre.fields import String, Enum
-
-        class MitRecord(Record):
-            dct_provenance_s = String(default=u'MIT')
-            dc_rights_s = Enum(enums=[u'Public', u'Restricted'],
-                               default=u'Restricted')
-
-    :param kwargs: initial field values
-    """
-
-    uuid = String()
-    dc_identifier_s = String()
-    dc_title_s = String()
-    dc_description_s = String()
-    dc_rights_s = Enum(enums=['Public', 'Restricted'])
-    dct_provenance_s = String()
-    dct_references_s = Dictionary()
-    layer_id_s = String()
-    layer_geom_type_s = Enum(enums=['Point', 'Line', 'Polygon', 'Raster',
-                                'Scanned Map', 'Paper Map', 'Mixed'])
-    layer_modified_dt = DateTime(default=arrow.now())
-    layer_slug_s = String()
-    solr_year_i = Integer()
-    dc_creator_sm = Set()
-    dc_format_s = String()
-    dc_language_s = String()
-    dc_publisher_s = String()
-    dc_subject_sm = Set()
-    dc_type_s = Enum(enums=['Dataset', 'Image', 'PhysicalObject'])
-    dct_spatial_sm = Set()
-    dct_temporal_sm = Set()
-    dct_issued_dt = String()
-    dct_isPartOf_sm = Set()
-
-    _bbox_w = Decimal()
-    _bbox_n = Decimal()
-    _bbox_e = Decimal()
-    _bbox_s = Decimal()
-    _lat = Decimal()
-    _lon = Decimal()
+class Record(object):
+    dc_description_s = None
+    dc_identifier_s = None
+    dc_language_s = None
+    dc_publisher_s = None
+    dc_title_s = None
+    dct_issued_dt = None
+    dct_provenance_s = None
+    geoblacklight_version = None
+    layer_id_is = None
+    layer_modified_dt = None
+    layer_slug_s = None
 
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
 
     @property
-    def georss_box_s(self):
-        bounds = (self._bbox_s, self._bbox_w, self._bbox_n, self._bbox_e)
-        if None in bounds:
-            return None
-        return "%s %s %s %s" % bounds
+    @optional
+    def dc_creator_sm(self):
+        return self._dc_creator_sm
+
+    @dc_creator_sm.setter
+    def dc_creator_sm(self, value):
+        self._dc_creator_sm = set(value)
+
+    @property
+    @optional
+    def dc_format_s(self):
+        return self._dc_format_s
+
+    @dc_format_s.setter
+    @Enum('Shapefile', 'GeoTiff', 'ArcGRID')
+    def dc_format_s(self, value):
+        self._dc_format_s = value
+
+    @property
+    def dc_rights_s(self):
+        return self._dc_rights_s
+
+    @dc_rights_s.setter
+    @Enum('Public', 'Restricted')
+    def dc_rights_s(self, value):
+        self._dc_rights_s = value
+
+    @property
+    @optional
+    def dc_source_sm(self):
+        return self._dc_source_sm
+
+    @dc_source_sm.setter
+    def dc_source_sm(self, value):
+        self._dc_source_dm = set(value)
+
+    @property
+    @optional
+    def dc_subject_sm(self):
+        return self._dc_subject_sm
+
+    @dc_subject_sm.setter
+    def dc_subject_sm(self, value):
+        self._dc_subject_sm = set(value)
+
+    @property
+    @optional
+    def dc_type_s(self):
+        return self._dc_type_s
+
+    @dc_type_s.setter
+    @Enum('Dataset', 'Image', 'PhysicalObject')
+    def dc_type_s(self, value):
+        self._dc_type_s = value
+
+    @property
+    @optional
+    def dct_isPartOf_sm(self):
+        return self._dct_isPartOf_sm
+
+    @dct_isPartOf_sm.setter
+    def dct_isPartOf_sm(self, value):
+        self._dct_isPartOf_sm = set(value)
+
+    @property
+    def dct_references_s(self):
+        return self._dct_references_s
+
+    @dct_references_s.setter
+    def dct_references_s(self, value):
+        self._dct_references_s = dict(value)
+
+    @property
+    @optional
+    def dct_spatial_sm(self):
+        return self._dct_spatial_sm
+
+    @dct_spatial_sm.setter
+    def dct_spatial_sm(self, value):
+        self._dct_spatial_sm = set(value)
+
+    @property
+    @optional
+    def dct_temporal_sm(self):
+        return self._dct_temporal_sm
+
+    @dct_temporal_sm.setter
+    def dct_temporal_sm(self, value):
+        self._dct_temporal_sm = set(value)
+
+    @property
+    def layer_geom_type_s(self):
+        return self._layer_geom_type_s
+
+    @layer_geom_type_s.setter
+    @Enum('Point', 'Line', 'Polygon', 'Raster', 'Scanned Map', 'Mixed')
+    def layer_geom_type_s(self, value):
+        self._layer_geom_type_s = value
 
     @property
     def solr_geom(self):
-        bounds = (self._bbox_w, self._bbox_e, self._bbox_n, self._bbox_s)
-        if None in bounds:
-            return None
-        return "ENVELOPE(%s, %s, %s, %s)" % bounds
+        return self._solr_geom
 
-    @property
-    def georss_point_s(self):
-        point = (self._lat, self._lon)
-        if None in point:
-            return None
-        return "%s %s" % point
+    @solr_geom.setter
+    def solr_geom(self, values):
+        """W,E,N,S"""
+        self._solr_geom = "ENVELOPE({}, {}, {}, {})".format(*values)
 
-    def as_dict(self):
-        """Return record as a dictionary.
-
-        This dictionary will contain only fields present in the current
-        version of the GeoBlacklight schema.
-
-        The ``dct_references_s`` field, if not ``None``, will be
-        represented as a valid JSON string.
-
-        :rtype: dictionary
-        """
-
-        if self.dct_references_s:
-            references = json.dumps(self.dct_references_s)
-        else:
-            references = None
-        d = {
-            'uuid': self.uuid,
-            'dc_identifier_s': self.dc_identifier_s,
-            'dc_title_s': self.dc_title_s,
+    def to_json(self):
+        record = {
+            'dc_creator_sm': list(self.dc_creator_sm or []),
             'dc_description_s': self.dc_description_s,
+            'dc_format_s': self.dc_format_s,
+            'dc_identifier_s': self.dc_identifier_s,
+            'dc_language_s': self.dc_language_s,
+            'dc_publisher_s': self.dc_publisher_s,
             'dc_rights_s': self.dc_rights_s,
+            'dc_source_sm': list(self.dc_source_sm or []),
+            'dc_subject_sm': list(self.dc_subject_sm or []),
+            'dc_title_s': self.dc_title_s,
+            'dc_type_s': self.dc_type_s,
+            'dct_isPartOf_sm': list(self.dct_isPartOf_sm or []),
+            'dct_issued_dt': self.dct_issued_dt,
             'dct_provenance_s': self.dct_provenance_s,
-            'dct_references_s': references,
-            'georss_box_s': self.georss_box_s,
-            'layer_id_s': self.layer_id_s,
+            'dct_references_s': self.dct_references_s,
+            'dct_spatial_sm': list(self.dct_spatial_sm or []),
+            'dct_temporal_sm': list(self.dct_temporal_sm or []),
+            'geoblacklight_version': self.geoblacklight_version,
             'layer_geom_type_s': self.layer_geom_type_s,
+            'layer_id_s': self.layer_id_s,
             'layer_modified_dt': self.layer_modified_dt,
             'layer_slug_s': self.layer_slug_s,
             'solr_geom': self.solr_geom,
-            'solr_year_i': self.solr_year_i,
-            'dc_creator_sm': self.dc_creator_sm,
-            'dc_format_s': self.dc_format_s,
-            'dc_language_s': self.dc_language_s,
-            'dc_publisher_s': self.dc_publisher_s,
-            'dc_subject_sm': self.dc_subject_sm,
-            'dc_type_s': self.dc_type_s,
-            'dct_spatial_sm': self.dct_spatial_sm,
-            'dct_temporal_sm': self.dct_temporal_sm,
-            'dct_issued_dt': self.dct_issued_dt,
-            'dct_isPartOf_sm': self.dct_isPartOf_sm,
-            'georss_point_s': self.georss_point_s,
         }
-
-        return dict((k, v) for k, v in d.items() if v)
+        return json.dumps({k: v for k,v in record.items() if v})

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -1,73 +1,34 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import unittest
-import pytest
-import arrow
 import json
+
+import pytest
 
 from ogre.record import Record
 from ogre.exceptions import InvalidDataError
 
 
-class RecordTestCase(unittest.TestCase):
-    def testRecordInitializesFromData(self):
-        r = Record(dc_rights_s='Public')
-        self.assertEqual(r.dc_rights_s, 'Public')
+def testRecordInitializesFromData():
+    r = Record(dc_rights_s='Public')
+    assert r.dc_rights_s == 'Public'
 
-    def testEnumRaisesExceptionForUnknownValue(self):
-        with pytest.raises(InvalidDataError):
-            Record(dc_rights_s='Level 8')
 
-    def testStringFieldStripsWhitespaceByDefault(self):
-        r = Record(dc_title_s='Geothermal resources of New Mexico ')
-        self.assertEqual(r.dc_title_s, 'Geothermal resources of New Mexico')
+def testEnumRaisesExceptionForUnknownValue():
+    with pytest.raises(InvalidDataError):
+        Record(dc_rights_s='Level 8')
 
-    def testGeoRssConstructsRssString(self):
-        r = Record(_bbox_w='-20.5', _bbox_e='20', _bbox_s='-10',
-                      _bbox_n='10.0')
-        self.assertEqual(r.georss_box_s, '-10 -20.5 10.0 20')
 
-    def testDateTimeConstructsDateTime(self):
-        r = Record(layer_modified_dt='2015-01-01T12:12:12Z')
-        self.assertEqual(r.layer_modified_dt.year, 2015)
+def testRecordHasOptionalFields():
+    r = Record()
+    assert r.dc_creator_sm is None
 
-    def testModifiedUsesDefaultDatetime(self):
-        r = Record()
-        self.assertEqual(r.layer_modified_dt.year, arrow.now().year)
 
-    def testSolrGeomConstructsGeomString(self):
-        r = Record(_bbox_w='-20.5', _bbox_e='20', _bbox_s='-10',
-                      _bbox_n='10.0')
-        self.assertEqual(r.solr_geom, 'ENVELOPE(-20.5, 20, 10.0, -10)')
+def testSolrGeomConstructsGeomString():
+    r = Record()
+    r.solr_geom = '-20.5', '20', '10.0', '-10'
+    assert r.solr_geom == 'ENVELOPE(-20.5, 20, 10.0, -10)'
 
-    def testIntegerFieldConvertsToInteger(self):
-        r = Record(solr_year_i='1999')
-        self.assertEqual(r.solr_year_i, 1999)
 
-    def testSetFieldRemovesDuplicates(self):
-        r = Record(dc_creator_sm=['Bubbles', 'Bubbles'])
-        self.assertEqual(r.dc_creator_sm, set(['Bubbles']))
-
-    def testGeoRssPointConstructsRssString(self):
-        r = Record(_lat='45', _lon='-180')
-        self.assertEqual(r.georss_point_s, '45 -180')
-
-    def testAsDictReturnsReferencesAsJson(self):
-        references = {
-            'http://schema.org/Person': 'Britney Spears',
-        }
-        r = Record(dct_references_s=references)
-        self.assertEqual(r.as_dict().get('dct_references_s'),
-                         json.dumps(references))
-
-    def testAsDictRemovesEmptyFields(self):
-        r = Record(uuid='123')
-        assert 'dc_title_s' not in r.as_dict()
-
-    def testRecordCanBeRepresentedAsDictionary(self):
-        time = arrow.now()
-        r = Record(uuid='0-8-3', dc_title_s='Today, in the world of cats',
-                      _lat='-23', _lon='97', layer_modified_dt=time)
-        self.assertEqual(r.as_dict(),
-            {'uuid': '0-8-3', 'dc_title_s': 'Today, in the world of cats',
-             'georss_point_s': '-23 97', 'layer_modified_dt': time})
+def testSetFieldRemovesDuplicates():
+    r = Record(dc_creator_sm=['Bubbles', 'Bubbles'])
+    assert r.dc_creator_sm == set(['Bubbles'])

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean, py27, py33, py34, docs, coverage
+envlist = clean, py27, py35, docs, coverage
 
 [testenv]
 commands =


### PR DESCRIPTION
This updates the record to reflect changes to the schema. This also
replaces the use of descriptors with properties. The properties are
easier to manage and more flexible.
